### PR TITLE
Fix for "use of $this on a non object context"

### DIFF
--- a/src/Minify/View/Helper/MinifyHelper.php
+++ b/src/Minify/View/Helper/MinifyHelper.php
@@ -30,7 +30,8 @@ class MinifyHelper extends AbstractHelper
 		// create minified file
 		if(! $finalMinifyName) {
 			$finalMinifyName = $this->getFilePrefix().$hash."-".uniqid().".".$this->getFilesExtension($filesToMinify);
-			file_put_contents($pathMinify."/".$finalMinifyName, Minify::combine($filesToMinify));
+			$m = new Minify(new \Minify_Cache_Null());
+			file_put_contents($pathMinify."/".$finalMinifyName, $m->combine($filesToMinify));
 		}
 
 		return $this->findWebPathMinify($file)."/".$finalMinifyName;


### PR DESCRIPTION
The error occurred because mrclay/minify uses $this->cache inside the combine method and the view helper were calling Minify::combine